### PR TITLE
allowed ability to override SenderReceiverSerializer via SENDER_RECEIVER_SERIALIZER setting

### DIFF
--- a/django_messages_drf/serializers.py
+++ b/django_messages_drf/serializers.py
@@ -48,8 +48,13 @@ class InboxSerializer(serializers.ModelSerializer):
         if message:
             return message.content[:50]
 
+    @property
+    def sender_receiver_klass(self):
+        from .settings import SENDER_RECEIVER_SERIALIZER
+        return SENDER_RECEIVER_SERIALIZER
+
     def get_sender(self, instance): # pragma: no cover
-        serializer = SenderReceiverSerializer(context=self.context)
+        serializer = self.sender_receiver_klass(context=self.context)
         message = instance.last_message()
         if message:
             return serializer.to_representation(message.sender)
@@ -69,8 +74,13 @@ class MessageSerializer(serializers.ModelSerializer):
         model = Message
         exclude = ('id', 'thread',)
 
+    @property
+    def sender_receiver_klass(self):
+        from .settings import SENDER_RECEIVER_SERIALIZER
+        return SENDER_RECEIVER_SERIALIZER
+
     def get_sender(self, instance):
-        serializer = SenderReceiverSerializer(context=self.context)
+        serializer = self.sender_receiver_klass(context=self.context)
         return serializer.to_representation(instance.sender)
 
 

--- a/django_messages_drf/settings.py
+++ b/django_messages_drf/settings.py
@@ -6,7 +6,13 @@ from django.conf import settings
 from django.utils.module_loading import import_string
 from typing import Any
 
-from .serializers import (InboxSerializer, ThreadSerializer, ThreadReplySerializer, EditMessageSerializer)
+from .serializers import (
+    EditMessageSerializer,
+    InboxSerializer,
+    SenderReceiverSerializer,
+    ThreadSerializer,
+    ThreadReplySerializer
+)
 
 
 def get_serializer_by_settings(default: Any, setting_name: str):
@@ -30,3 +36,4 @@ INBOX_SERIALIZER = get_serializer_by_settings(InboxSerializer, 'DJANGO_MESSAGES_
 THREAD_SERIALIZER = get_serializer_by_settings(ThreadSerializer, 'DJANGO_MESSAGES_DRF_THREAD_SERIALIZER')
 THREAD_REPLY_SERIALIZER = get_serializer_by_settings(ThreadReplySerializer, 'DJANGO_MESSAGES_DRF_MESSAGE_SERIALIZER')
 EDIT_MESSAGE_SERIALIZER = get_serializer_by_settings(EditMessageSerializer, 'DJANGO_MESSAGES_DRF_EDIT_MESSAGE_SERIALIZER')
+SENDER_RECEIVER_SERIALIZER = get_serializer_by_settings(SenderReceiverSerializer, 'DJANGO_MESSAGES_DRF_SENDER_RECEIVER_SERIALIZER')


### PR DESCRIPTION
Since `SenderReceiverSerializer` is a nested Serializer, it required updating all the individual serializers to update the was users are serialized.

By adding a new setting, users can choose to update only the user serializer.
New setting is called `SENDER_RECEIVER_SERIALIZER`.