### PR TITLE
Mark new thread as active configurable

### DIFF
--- a/django_messages_drf/models.py
+++ b/django_messages_drf/models.py
@@ -161,6 +161,10 @@ class Message(models.Model):
     content = models.TextField()
 
     @classmethod
+    def default_new_message_deleted(cls):
+        return getattr(settings, 'DJANGO_MESSAGES_MARK_NEW_THREAD_MESSAGE_AS_DELETED', True)
+
+    @classmethod
     def new_reply(cls, thread, user, content):
         """
         Create a new reply for an existing Thread. Mark thread as unread for all other participants,
@@ -190,7 +194,7 @@ class Message(models.Model):
                 thread = Thread.objects.create(subject=subject)
                 for user in to_users:
                     thread.userthread_set.create(user=user, deleted=False, unread=True)
-                thread.userthread_set.create(user=from_user, deleted=True, unread=False)
+                thread.userthread_set.create(user=from_user, deleted=cls.default_new_message_deleted(), unread=False)
                 msg = cls.objects.create(thread=thread, sender=from_user, content=content)
                 message_sent.send(sender=cls, message=msg, thread=thread, reply=False)
             except OperationalError as e:

--- a/django_messages_drf/settings.py
+++ b/django_messages_drf/settings.py
@@ -22,7 +22,7 @@ def get_serializer_by_settings(default: Any, setting_name: str):
         return default
     try:
         return import_string(path)
-    except ImportError as e : # pragma: no cover
+    except ImportError as e:  # pragma: no cover
         raise e
 
 # Default settings for the serializers

--- a/django_messages_drf/tests/test_cases.py
+++ b/django_messages_drf/tests/test_cases.py
@@ -1,5 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.test import override_settings, TestCase
 
 import django_messages_drf.tests.factories
 
@@ -51,6 +51,17 @@ class TestMessages(BaseTest):
         self.assertEqual(
             Thread.objects.get(pk=thread.pk).first_message.content,
             message_string)
+
+    @override_settings(DJANGO_MESSAGES_MARK_NEW_THREAD_MESSAGE_AS_DELETED=False)
+    def test_message_methods_with_default_active(self):
+        message_string = "You can't be serious"
+        Message.new_message(
+            self.brosner, [self.jtauber], "Really?", message_string)
+
+        self.assertEqual(Thread.inbox(self.brosner).count(), 1)
+        self.assertEqual(Thread.inbox(self.jtauber).count(), 1)
+        self.assertEqual(Thread.unread(self.brosner).count(), 0)
+        self.assertEqual(Thread.unread(self.jtauber).count(), 1)
 
     def test_ordered(self):
         """

--- a/django_messages_drf/tests/test_settings.py
+++ b/django_messages_drf/tests/test_settings.py
@@ -1,4 +1,10 @@
-from ..settings import (get_serializer_by_settings, InboxSerializer, ThreadSerializer, ThreadReplySerializer, EditMessageSerializer)
+from ..settings import (
+    get_serializer_by_settings,
+    InboxSerializer,
+    ThreadSerializer,
+    ThreadReplySerializer,
+    EditMessageSerializer
+)
 from django.test import TestCase
 from django.test import override_settings
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,4 +1,4 @@
-# Settings
+# Serializer Settings
 
 Django Messages DRF allows overriding some settings for the views, which means, instead of creating
 a new view just to apply your own serializer, you can simply override the setting and
@@ -32,3 +32,15 @@ DJANGO_MESSAGES_DRF_THREAD_SERIALIZER = 'myapp.serializers.MyCustomThreadSeriali
 ```
 
 If none of the settings is overridden or is **`None`** , then it will default to the original.
+
+# Behaviour Settings
+
+Django Messages DRF allows overriding some behaviours.
+
+## Overriding
+
+In your **`settings.py`**.
+
+| Setting Name  | Behaviour | Type   | Default |
+| :--------     | :-----    | :----- | :-----  |
+| __DJANGO_MESSAGES_MARK_NEW_THREAD_MESSAGE_AS_DELETED__ | Mark the first message sent as deleted | Boolean | True |


### PR DESCRIPTION
When a user creates a new thread, that thread is not visible in their inbox. This is because when a new thread is created, it is marked as `deleted=True` for that user. Some users of the library might prefer to mark it as `deleted=False`.

So this PR adds a new setting, `DJANGO_MESSAGES_MARK_NEW_THREAD_MESSAGE_AS_DELETED`, to control whether new threads are marked as active or not.

Refs https://github.com/tarsil/django-messages-drf/issues/8
